### PR TITLE
Deprecated Nette\Object && Wrong function usage

### DIFF
--- a/src/PresenterProfiler.php
+++ b/src/PresenterProfiler.php
@@ -90,7 +90,7 @@ trait PresenterProfiler
 	{
 		$this->methodCalls[$method] += 1;
 
-		if (count($this->methodCalls[$method]) === 1) {
+		if ($this->methodCalls[$method] === 1) {
 			$_ENV[$envKey] = microtime(TRUE);
 		}
 	}

--- a/tests/FunctionMocks.php
+++ b/tests/FunctionMocks.php
@@ -2,13 +2,14 @@
 
 namespace DamejidloTests\NewRelic;
 
-use Nette\Object;
+use Nette;
 use Tester\Assert;
 
 
 
-class FunctionMocks extends Object
+class FunctionMocks
 {
+	use Nette\SmartObject;
 
 	/**
 	 * @var int[]


### PR DESCRIPTION
- Added usage of trait "Nette\SmartObject" instead of inheriting from "Nette\Object" class.
- Fix: Wrong usage of "count()" function. 